### PR TITLE
Prevent nil pointer dereference with sessions

### DIFF
--- a/pwd/session.go
+++ b/pwd/session.go
@@ -183,6 +183,10 @@ func (p *pwd) SessionGet(sessionId string) *types.Session {
 
 	s, _ := p.storage.SessionGet(sessionId)
 
+	if s == nil {
+		return nil
+	}
+
 	if err := p.prepareSession(s); err != nil {
 		log.Println(err)
 		return nil


### PR DESCRIPTION
Triggered when creating a session, canceling it and reloading the "session" page.
URL used to trigger it: `http://host2.labs.play-with-k8s.com/p/2200d6e4-2b12-48a9-8f15-4a3234b30394#2200d6e4_node1`

Stacktrace:
```
PANIC: runtime error: invalid memory address or nil pointer dereference
goroutine 10193855 [running]:
github.com/urfave/negroni.(*Recovery).ServeHTTP.func1(0x7fded0e555f8, 0xc420e48688, 0xc4203c1170)
	/go/src/github.com/urfave/negroni/recovery.go:41 +0x13a
panic(0x16666a0, 0x2132500)
	/usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/play-with-docker/play-with-docker/pwd/types.(*Session).Lock(0x0)
	/go/src/github.com/play-with-docker/play-with-docker/pwd/types/session.go:28 +0x22
github.com/play-with-docker/play-with-docker/pwd.(*pwd).prepareSession(0xc420575740, 0x0, 0x0, 0x0)
	/go/src/github.com/play-with-docker/play-with-docker/pwd/session.go:290 +0x58
github.com/play-with-docker/play-with-docker/pwd.(*pwd).SessionGet(0xc420575740, 0xc4212c06c7, 0x24, 0x0)
	/go/src/github.com/play-with-docker/play-with-docker/pwd/session.go:189 +0xc7
github.com/play-with-docker/play-with-docker/handlers.Home(0x7fded0e555f8, 0xc420e48688, 0xc420a98a00)
	/go/src/github.com/play-with-docker/play-with-docker/handlers/home.go:13 +0x8f
net/http.HandlerFunc.ServeHTTP(0x18983b0, 0x7fded0e555f8, 0xc420e48688, 0xc420a98a00)
	/usr/local/go/src/net/http/server.go:1942 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc420276dc0, 0x7fded0e555f8, 0xc420e48688, 0xc420a98a00)
	/go/src/github.com/gorilla/mux/mux.go:114 +0x10c
github.com/urfave/negroni.Wrap.func1(0x7fded0e555f8, 0xc420e48688, 0xc421546700, 0xc420ca88e0)
	/go/src/github.com/urfave/negroni/negroni.go:46 +0x4d
github.com/urfave/negroni.HandlerFunc.ServeHTTP(0xc4201c36c0, 0x7fded0e555f8, 0xc420e48688, 0xc421546700, 0xc420ca88e0)
...
```